### PR TITLE
Fixed 2 bugs for the NginxConfigParser Parse function

### DIFF
--- a/config_parser.cc
+++ b/config_parser.cc
@@ -50,10 +50,6 @@ std::string NginxConfigStatement::ToString(int depth) {
   return serialized_statement;
 }
 
-NginxConfigParser::NginxConfigParser()
-{
-  num_unmatched_open_braces = 0;
-}
 const char* NginxConfigParser::TokenTypeAsString(TokenType type) {
   switch (type) {
     case TOKEN_TYPE_START:         return "TOKEN_TYPE_START";
@@ -152,6 +148,7 @@ NginxConfigParser::TokenType NginxConfigParser::ParseToken(std::istream* input,
 }
 
 bool NginxConfigParser::Parse(std::istream* config_file, NginxConfig* config) {
+  int num_unmatched_open_braces = 0;
   std::stack<NginxConfig*> config_stack;
   config_stack.push(config);
   TokenType last_token_type = TOKEN_TYPE_START;
@@ -209,7 +206,6 @@ bool NginxConfigParser::Parse(std::istream* config_file, NginxConfig* config) {
       if ((last_token_type != TOKEN_TYPE_STATEMENT_END && last_token_type != TOKEN_TYPE_END_BLOCK) 
         || num_unmatched_open_braces <= 0) {
         // Error.
-        printf("error found\n");
         break;
       }
       config_stack.pop();

--- a/config_parser.h
+++ b/config_parser.h
@@ -25,7 +25,7 @@ class NginxConfig {
 // The driver that parses a config file and generates an NginxConfig.
 class NginxConfigParser {
  public:
-  NginxConfigParser();
+  NginxConfigParser(){}
 
   // Take a opened config file or file name (respectively) and store the
   // parsed config in the provided NginxConfig out-param.  Returns true
@@ -45,8 +45,6 @@ class NginxConfigParser {
     TOKEN_TYPE_ERROR = 7
   };
   const char* TokenTypeAsString(TokenType type);
-
-  int num_unmatched_open_braces;
 
   enum TokenParserState {
     TOKEN_STATE_INITIAL_WHITESPACE = 0,

--- a/config_parser.h
+++ b/config_parser.h
@@ -25,7 +25,7 @@ class NginxConfig {
 // The driver that parses a config file and generates an NginxConfig.
 class NginxConfigParser {
  public:
-  NginxConfigParser() {}
+  NginxConfigParser();
 
   // Take a opened config file or file name (respectively) and store the
   // parsed config in the provided NginxConfig out-param.  Returns true
@@ -45,6 +45,8 @@ class NginxConfigParser {
     TOKEN_TYPE_ERROR = 7
   };
   const char* TokenTypeAsString(TokenType type);
+
+  int num_unmatched_open_braces;
 
   enum TokenParserState {
     TOKEN_STATE_INITIAL_WHITESPACE = 0,

--- a/config_parser_test.cc
+++ b/config_parser_test.cc
@@ -1,11 +1,64 @@
+#include <sstream>
+#include <string>
+
 #include "gtest/gtest.h"
 #include "config_parser.h"
 
+// test of file config
 TEST(NginxConfigParserTest, SimpleConfig) {
   NginxConfigParser parser;
   NginxConfig out_config;
 
   bool success = parser.Parse("example_config", &out_config);
-
   EXPECT_TRUE(success);
 }
+
+//simple testing of ToString function
+TEST(NginxConfigTest, ToString){
+	NginxConfigStatement statement;
+	statement.tokens_.push_back("foo");
+	statement.tokens_.push_back("bar");
+	EXPECT_EQ(statement.ToString(0), "foo bar;\n");
+
+}
+
+class NginxStringConfigTest : public ::testing::Test {
+protected:
+	bool ParseString(const std::string config_string){
+		std::stringstream config_stream(config_string);
+		return parser_.Parse(&config_stream, &out_config_);
+	}
+	
+	NginxConfigParser parser_;
+	NginxConfig out_config_;
+};
+
+
+//tests that a simple valid config for true
+//tests that the config output data structure is valid
+TEST_F(NginxStringConfigTest, AnotherSimpleConfig) {
+	EXPECT_TRUE(ParseString("foo bar;"));
+	EXPECT_EQ(out_config_.statements_.size(), 1);
+	EXPECT_EQ(out_config_.statements_.at(0)->tokens_.at(0), "foo");
+}
+
+//tests a simple invalid config for false
+TEST_F(NginxStringConfigTest, InvalidConfig) {
+	EXPECT_FALSE(ParseString("foo bar"));
+}
+
+//This one fails, unbalance number of open and closed brackets
+//FIXED: Kept track of number of open and closed brackets
+TEST_F(NginxStringConfigTest, UnbalancedConfig)
+{
+	EXPECT_FALSE(ParseString("server { listen 80;"));
+}
+
+// This one fails, Cannot handle a nested config
+// FIXED: A closed bracket can be followed by a semicolon OR a another clsoed bracket
+TEST_F(NginxStringConfigTest, NestedConfig){
+	EXPECT_TRUE(ParseString("foo bar; \nOutside { inside { foo bar; } }"));
+	std::string s = out_config_.ToString(0);
+	EXPECT_EQ(s, "foo bar;\nOutside {\n  inside {\n    foo bar;\n  }\n}\n");
+}
+


### PR DESCRIPTION
First bug was a unbalanced config statement (Ex. Sample { foo bar; ). The second bug was a nested config was not working (Ex. Sample { Sample2 { foo bar; } } ).